### PR TITLE
feat: add logic to get video details

### DIFF
--- a/src/YouTubeSubtitlesExtractor/Abstractions/IYouTubeVideo.cs
+++ b/src/YouTubeSubtitlesExtractor/Abstractions/IYouTubeVideo.cs
@@ -19,7 +19,7 @@ public interface IYouTubeVideo
     /// </summary>
     /// <param name="videoUrl">YouTube video URL.</param>
     /// <returns>Returns a <see cref="VideoDetail"/> instance containing video details.</returns>
-    Task<VideoDetail> GetVideoDetail(string videoUrl);
+    Task<VideoDetails> GetVideoDetails(string videoUrl);
 
     /// <summary>
     /// Extracts the subtitles from the given video options.

--- a/src/YouTubeSubtitlesExtractor/Abstractions/IYouTubeVideo.cs
+++ b/src/YouTubeSubtitlesExtractor/Abstractions/IYouTubeVideo.cs
@@ -15,6 +15,13 @@ public interface IYouTubeVideo
     string GetVideoId(string videoUrl);
 
     /// <summary>
+    /// Gets video details including title, description and available subtitle languages from the provided YouTube video URL.
+    /// </summary>
+    /// <param name="videoUrl">YouTube video URL.</param>
+    /// <returns>Returns a <see cref="VideoDetail"/> instance containing video details.</returns>
+    Task<VideoDetail> GetVideoDetail(string videoUrl);
+
+    /// <summary>
     /// Extracts the subtitles from the given video options.
     /// </summary>
     /// <param name="videoUrl">YouTube video URL.</param>

--- a/src/YouTubeSubtitlesExtractor/Abstractions/IYouTubeVideo.cs
+++ b/src/YouTubeSubtitlesExtractor/Abstractions/IYouTubeVideo.cs
@@ -19,7 +19,7 @@ public interface IYouTubeVideo
     /// </summary>
     /// <param name="videoUrl">YouTube video URL.</param>
     /// <returns>Returns a <see cref="VideoDetail"/> instance containing video details.</returns>
-    Task<VideoDetails> GetVideoDetails(string videoUrl);
+    Task<VideoDetails> GetVideoDetailsAsync(string videoUrl);
 
     /// <summary>
     /// Extracts the subtitles from the given video options.

--- a/src/YouTubeSubtitlesExtractor/Models/VideoDetail.cs
+++ b/src/YouTubeSubtitlesExtractor/Models/VideoDetail.cs
@@ -5,18 +5,5 @@ namespace Aliencube.YouTubeSubtitlesExtractor.Models;
 /// </summary>
 public class VideoDetails
 {
-    /// <summary>
-    /// Gets or sets the video title.
-    /// </summary>
-    public string Title { get; set; }
-
-    /// <summary>
-    /// Gets or sets the video description.
-    /// </summary>
-    public string Description { get; set; }
-
-    /// <summary>
-    /// Gets or sets the list of available subtitle languages.
-    /// </summary>
-    public List<string> AvailableSubtitleLanguages { get; set; }
+    /// Forthcoming
 }

--- a/src/YouTubeSubtitlesExtractor/Models/VideoDetail.cs
+++ b/src/YouTubeSubtitlesExtractor/Models/VideoDetail.cs
@@ -3,7 +3,7 @@ namespace Aliencube.YouTubeSubtitlesExtractor.Models;
 /// <summary>
 /// This represents the video details entity.
 /// </summary>
-public class VideoDetail
+public class VideoDetails
 {
     /// <summary>
     /// Gets or sets the video title.

--- a/src/YouTubeSubtitlesExtractor/Models/VideoDetail.cs
+++ b/src/YouTubeSubtitlesExtractor/Models/VideoDetail.cs
@@ -1,0 +1,22 @@
+namespace Aliencube.YouTubeSubtitlesExtractor.Models;
+
+/// <summary>
+/// This represents the video details entity.
+/// </summary>
+public class VideoDetail
+{
+    /// <summary>
+    /// Gets or sets the video title.
+    /// </summary>
+    public string Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the video description.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of available subtitle languages.
+    /// </summary>
+    public List<string> AvailableSubtitleLanguages { get; set; }
+}

--- a/src/YouTubeSubtitlesExtractor/YouTubeVideo.cs
+++ b/src/YouTubeSubtitlesExtractor/YouTubeVideo.cs
@@ -35,7 +35,7 @@ public class YouTubeVideo : IYouTubeVideo
     }
 
     /// <inheritdoc/>
-    public async Task<VideoDetail> GetVideoDetail(string videoUrl)
+    public async Task<VideoDetails> GetVideoDetails(string videoUrl)
     {
         throw new NotImplementedException();
     }

--- a/src/YouTubeSubtitlesExtractor/YouTubeVideo.cs
+++ b/src/YouTubeSubtitlesExtractor/YouTubeVideo.cs
@@ -35,6 +35,12 @@ public class YouTubeVideo : IYouTubeVideo
     }
 
     /// <inheritdoc/>
+    public async Task<VideoDetail> GetVideoDetail(string videoUrl)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc/>
     public async Task<Subtitle> ExtractSubtitleAsync(string videoUrl, string languageCode = "en")
     {
         var options = new VideoOptions() { VideoUrl = videoUrl, LanguageCodes = { languageCode } };

--- a/src/YouTubeSubtitlesExtractor/YouTubeVideo.cs
+++ b/src/YouTubeSubtitlesExtractor/YouTubeVideo.cs
@@ -35,7 +35,7 @@ public class YouTubeVideo : IYouTubeVideo
     }
 
     /// <inheritdoc/>
-    public async Task<VideoDetails> GetVideoDetails(string videoUrl)
+    public async Task<VideoDetails> GetVideoDetailsAsync(string videoUrl)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
This PR addresses issue #3 and adds the ability to retrieve video details from YouTube URLs. Key changes include:

- Introducing the `GetVideoDetails` method in the `IYouTubeVideo` interface.
- Creating the `VideoDetail` class to store video title, description, and subtitle languages.
- Implementing the `GetVideoDetails` method in `YouTubeVideo.cs`.

The goal is to make it easier for users to access essential video information. Your feedback is appreciated as we work to enhance this library.