### PR TITLE
docs: add extract option using details

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ This is the NuGet package library that retrieves subtitles from a given YouTube 
 
     ```csharp
     // Extract video details including title, description and available subtitle languagesfrom the given YouTube video URL.
-    VideoDetails details = await youtube.ExtractDetailsAsync(youtubeUrl);
+    VideoDetails details = await youtube.ExtractVideoDetailsAsync(youtubeUrl);
 
     // Extract a single subtitle from the given YouTube video URL.
     // - defaults to English (en)
-    var subtitle = await youtube.ExtractSubtitleAsync(youtubeUrl);
+    Subtitle subtitle = await youtube.ExtractSubtitleAsync(youtubeUrl);
 
     // Extract a single subtitle from the given YouTube video URL with the specified language code.
     // eg) Korean (ko)
-    var subtitle = await youtube.ExtractSubtitleAsync(youtubeUrl, "ko");
+    Subtitle subtitle = await youtube.ExtractSubtitleAsync(youtubeUrl, "ko");
 
     // Extract list of subtitles from the given VideoOptions instance.
     // eg) English and Korean (ko)
     var options = new VideoOptions { Url = youtubeUrl, LanguageCodes = { "en", "ko" } };
-    var subtitles = await youtube.ExtractSubtitlesAsync(options);
+    List<Subtitle> subtitles = await youtube.ExtractSubtitlesAsync(options);
     ```
 
 ## Issues or Feedbacks

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is the NuGet package library that retrieves subtitles from a given YouTube 
 1. Extract subtitles from the given YouTube video URL. There are a few options to extract subtitles.
 
     ```csharp
-    // Extract video details including title, description and available subtitle languagesfrom the given YouTube video URL.
+    // Extract video details from the given YouTube video URL.
     VideoDetails details = await youtube.ExtractVideoDetailsAsync(youtubeUrl);
 
     // Extract a single subtitle from the given YouTube video URL.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This is the NuGet package library that retrieves subtitles from a given YouTube 
 1. Extract subtitles from the given YouTube video URL. There are a few options to extract subtitles.
 
     ```csharp
+    // Extract video details including title, description and available subtitle languagesfrom the given YouTube video URL.
+    VideoDetails details = await youtube.ExtractDetailsAsync(youtubeUrl);
+
     // Extract a single subtitle from the given YouTube video URL.
     // - defaults to English (en)
     var subtitle = await youtube.ExtractSubtitleAsync(youtubeUrl);


### PR DESCRIPTION
This PR addresses issue #5 and updates the README file to include information about how to extract video details from a YouTube video URL using our library. Key changes include:

- clear guidance to our users on how to utilize our library for extracting video information.
- replaced usage of var with the explicit type to enhance code readability and maintainability.

**Note that the mention of "detail properties" in the README is temporary.**
It is to show how the annotation should be written afterwards.

Please review and merge this PR as appropriate. Thank you!